### PR TITLE
[update] 회원가입 수정, 커스텀 에러 핸들링 추가

### DIFF
--- a/src/main/java/myproject/sns/domain/member/dao/UserRepository.java
+++ b/src/main/java/myproject/sns/domain/member/dao/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/myproject/sns/domain/member/service/UserService.java
+++ b/src/main/java/myproject/sns/domain/member/service/UserService.java
@@ -1,8 +1,6 @@
 package myproject.sns.domain.member.service;
 
-import lombok.RequiredArgsConstructor;
 import myproject.sns.domain.member.entity.ChangePasswordRequest;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
@@ -10,4 +8,5 @@ import java.security.Principal;
 @Service
 public interface UserService {
     void changePassword(ChangePasswordRequest request, Principal connectedUser);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/myproject/sns/domain/member/service/UserServiceImpl.java
+++ b/src/main/java/myproject/sns/domain/member/service/UserServiceImpl.java
@@ -3,8 +3,6 @@ package myproject.sns.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import myproject.sns.domain.member.dao.UserRepository;
 import myproject.sns.domain.member.entity.ChangePasswordRequest;
-import myproject.sns.domain.member.entity.User;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -21,4 +19,11 @@ public class UserServiceImpl implements UserService{
     public void changePassword(ChangePasswordRequest request, Principal connectedUser) {
         // TODO : 비밀번호 변경
     }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+
 }

--- a/src/main/java/myproject/sns/global/exception/CustomErrorCode.java
+++ b/src/main/java/myproject/sns/global/exception/CustomErrorCode.java
@@ -1,0 +1,15 @@
+package myproject.sns.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CustomErrorCode {
+
+    EMAIL_DUPLICATED(400, "이미 등록된 이메일입니다");
+
+    private final int status;
+    private final String message;
+
+}

--- a/src/main/java/myproject/sns/global/exception/CustomException.java
+++ b/src/main/java/myproject/sns/global/exception/CustomException.java
@@ -1,0 +1,10 @@
+package myproject.sns.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+    private final CustomErrorCode errorCode;
+}

--- a/src/main/java/myproject/sns/global/exception/ErrorResult.java
+++ b/src/main/java/myproject/sns/global/exception/ErrorResult.java
@@ -1,0 +1,11 @@
+package myproject.sns.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ErrorResult {
+    private String status;
+    private String message;
+}

--- a/src/main/java/myproject/sns/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/myproject/sns/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package myproject.sns.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 커스텀 예외 처리
+     * 1. CustomException에 상수 저장
+     * 2. 저장된 상수 값을 가지고 CustomErrorCode에서 name, message 추출
+     * 3. 에러 로깅
+     * 4. 커스텀 에러 이름과 메시지를 가진 ErrorResult 객체 반환
+     */
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResult> handleCustomException(CustomException ex) {
+        CustomErrorCode errorCode = ex.getErrorCode();
+        ErrorResult errorResult = new ErrorResult(errorCode.name(), errorCode.getMessage());
+        log.error("[GlobalExceptionHandler] errorCode: {}, message: {}", errorCode.name(), errorCode.getMessage());
+        return new ResponseEntity<>(errorResult, HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+    // 검증 실패 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResult> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        String errorMessage = ex.getAllErrors().get(0).getDefaultMessage();
+        ErrorResult errorResult = new ErrorResult("VALIDATION_ERROR", errorMessage);
+        log.error("[GlobalExceptionHandler] errorName: MethodArgumentNotValidException, message: {}", errorMessage);
+        return new ResponseEntity<>(errorResult, HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/main/java/myproject/sns/global/security/auth/RegisterRequest.java
+++ b/src/main/java/myproject/sns/global/security/auth/RegisterRequest.java
@@ -6,6 +6,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import myproject.sns.domain.member.entity.Role;
 
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 @Data
 @Builder
 @AllArgsConstructor
@@ -13,8 +17,17 @@ import myproject.sns.domain.member.entity.Role;
 public class RegisterRequest {
 
     private Long id;
+
+    @NotBlank(message = "이름 입력은 필수입니다")
     private String name;
+
+    @NotBlank(message = "이메일 입력은 필수입니다")
+    @Email
     private String email;
+
+    @NotBlank(message = "비밀번호 입력은 필수입니다")
+    @Size(min = 5, max = 50, message = "비밀번호는 5~50자 길이만 허용합니다")
     private String password;
+
     private Role role;
 }

--- a/src/main/java/myproject/sns/util/SnowflakeGenerator.java
+++ b/src/main/java/myproject/sns/util/SnowflakeGenerator.java
@@ -1,10 +1,12 @@
 package myproject.sns.util;
 
+import org.springframework.stereotype.Component;
 import java.net.NetworkInterface;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Enumeration;
 
+@Component
 public class SnowflakeGenerator {
     private static final int UNUSED_BITS = 1; // Sign bit, Unused (always set to 0)
     private static final int EPOCH_BITS = 41;

--- a/src/main/java/myproject/sns/web/controller/member/UserController.java
+++ b/src/main/java/myproject/sns/web/controller/member/UserController.java
@@ -4,15 +4,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import myproject.sns.domain.member.entity.ChangePasswordRequest;
 import myproject.sns.domain.member.service.UserService;
+import myproject.sns.global.exception.CustomException;
 import myproject.sns.global.security.auth.AuthenticationRequest;
 import myproject.sns.global.security.auth.AuthenticationResponse;
 import myproject.sns.global.security.auth.AuthenticationService;
 import myproject.sns.global.security.auth.RegisterRequest;
-import myproject.sns.util.SnowflakeGenerator;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+
+import static myproject.sns.global.exception.CustomErrorCode.EMAIL_DUPLICATED;
 
 @Slf4j
 @RestController
@@ -25,11 +28,12 @@ public class UserController {
 
     // 회원가입
     @PostMapping("/register")
-    public ResponseEntity<?> registerByUser(@RequestBody RegisterRequest request) {
-        SnowflakeGenerator idGenerator = new SnowflakeGenerator();
-        request.setId(idGenerator.nextId());
-        AuthenticationResponse registeredData = authenticationService.register(request);
-        return ResponseEntity.ok(registeredData);
+    public ResponseEntity<?> registerByUser(@Validated @RequestBody RegisterRequest request) {
+        if (userService.existsByEmail(request.getEmail())) {
+            throw new CustomException(EMAIL_DUPLICATED); // 이메일 중복 에러
+        }
+        authenticationService.register(request);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/authenticate")


### PR DESCRIPTION
- 회원가입(/register) 성공 시 토큰 발급이 되지 못하게 변경
- 커스텀 에러 핸들링을 위한 클래스들 추가
  - 커스텀 에러는 enum 클래스의 상수로 사용
- 이메일 중복 에러 추가