### PR TITLE
[feat] 사용자 홈페이지 추가

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,6 +8,11 @@
       "name": "front",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.5.1",
+        "@fortawesome/free-brands-svg-icons": "^6.5.1",
+        "@fortawesome/free-regular-svg-icons": "^6.5.1",
+        "@fortawesome/free-solid-svg-icons": "^6.5.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@material-tailwind/react": "^2.1.8",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -2593,6 +2598,75 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
       "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-093l7DAkx0aEtBq66Sf19MgoZewv1zeY9/4C7vSKPO4qMwEsW/2VYTUTpBtLwfb9T2R73tXaRDPmE4UqLCYHfg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-m6ShXn+wvqEU69wSP84coxLbNl7sGVZb+Ca+XZq6k30SzuP3X4TfPqtycgUh9ASwlNh5OfQCd8pDIWxl+O+LlQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/front/package.json
+++ b/front/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.5.1",
+    "@fortawesome/free-brands-svg-icons": "^6.5.1",
+    "@fortawesome/free-regular-svg-icons": "^6.5.1",
+    "@fortawesome/free-solid-svg-icons": "^6.5.1",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@material-tailwind/react": "^2.1.8",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -1,10 +1,15 @@
 import LoginPage from "./component/login/LoginPage";
+import {BrowserRouter, Route, Routes} from "react-router-dom";
+import HomePage from "./component/home/HomePage";
 
 function App() {
   return (
-      <div className="App">
-        <LoginPage />
-      </div>
+      <BrowserRouter>
+          <Routes>
+              <Route path="/login" Component={LoginPage} />
+              <Route path="/home" Component={HomePage} />
+          </Routes>
+      </BrowserRouter>
   );
 }
 export default App;

--- a/front/src/component/home/HomePage.jsx
+++ b/front/src/component/home/HomePage.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {faBars, faMagnifyingGlass} from "@fortawesome/free-solid-svg-icons";
+import {faBell, faEnvelope, faSquarePlus, faUser} from "@fortawesome/free-regular-svg-icons";
+
+import homeIcon from "../../img/home/icon_home.svg";
+
+
+const HomePage = () => {
+
+    return (
+        <div className="bg-white flex flex-row justify-center">
+            <div className="bg-white relative flex-auto">
+                <div className="absolute top-[66px] left-[62px] text-black text-[24px] font-sans font-normal tracking-[0] leading-[normal]">
+                    로고 이미지
+                </div>
+                <div className="top-[162px] inline-flex items-center gap-[24px] absolute left-[62px]">
+                    <img
+                        className="relative w-[31.2px] h-[28.09px] mt-[-1.60px] mb-[-1.60px] ml-[-1.60px]"
+                        alt="Icon home"
+                        src={homeIcon}
+                    />
+                    <div className="relative w-fit mt-[-0.56px] text-[#3e3e3e] text-[20px] whitespace-nowrap font-sans font-normal tracking-[0] leading-[normal]">
+                        홈
+                    </div>
+                </div>
+                <div className="top-[376px] inline-flex items-center gap-[24px] absolute left-[62px]">
+                    <FontAwesomeIcon className="relative w-[28px] h-[28px]" icon={faBell} />
+                    <div className="relative w-fit text-[#3e3e3e] text-[20px] whitespace-nowrap font-sans font-normal tracking-[0] leading-[normal]">
+                        알림
+                    </div>
+                </div>
+                <div className="top-[448px] inline-flex items-center gap-[24px] absolute left-[62px]">
+                    <FontAwesomeIcon className="relative w-[28px] h-[28px]" icon={faUser} />
+                    <div className="relative w-fit text-[#3e3e3e] text-[20px] whitespace-nowrap font-sans font-normal tracking-[0] leading-[normal]">
+                        프로필
+                    </div>
+                </div>
+                <div className="top-[520px] inline-flex items-center gap-[24px] absolute left-[62px]">
+                    <FontAwesomeIcon className="relative w-[27px] h-[30px]" icon={faSquarePlus} />
+                    <div className="relative w-fit text-[#3e3e3e] text-[20px] whitespace-nowrap font-sans font-normal tracking-[0] leading-[normal]">
+                        게시하기
+                    </div>
+                </div>
+                <div className="top-[306px] inline-flex items-center gap-[24px] absolute left-[62px]">
+                    <FontAwesomeIcon className="relative w-[28px] h-[28px]" icon={faEnvelope} />
+                    <div className="relative w-fit text-[#3e3e3e] text-[20px] whitespace-nowrap font-sans font-normal tracking-[0] leading-[normal]">
+                        메시지
+                    </div>
+                </div>
+                <div className="top-[234px] inline-flex items-center gap-[24px] absolute left-[62px]">
+                    <FontAwesomeIcon className="relative w-[28px] h-[28px]" icon={faMagnifyingGlass} />
+                    <div className="relative w-fit text-[#3e3e3e] text-[20px] whitespace-nowrap font-sans font-normal tracking-[0] leading-[normal]">
+                        검색
+                    </div>
+                </div>
+                <div className="top-[809px] inline-flex items-center gap-[24px] absolute left-[62px]">
+                    <FontAwesomeIcon className="relative w-[28px] h-[28px]" icon={faBars} />
+                    <div className="relative w-fit text-[#3e3e3e] text-[20px] whitespace-nowrap font-sans font-normal tracking-[0] leading-[normal]">
+                        더보기
+                    </div>
+                </div>
+            </div>
+            <div className="flex-auto relative top-[66px]">
+                게시글 표시 구역
+            </div>
+        </div>
+    );
+};
+
+export default HomePage

--- a/front/src/component/login/LoginPage.jsx
+++ b/front/src/component/login/LoginPage.jsx
@@ -1,14 +1,14 @@
-import { useState, useCallback } from 'react'
-import { Input } from "@material-tailwind/react";
+import {useState} from 'react'
 import axios from "axios";
 
 import socialLoginVector01 from '../../img/login/Vector 12_10.png'
 import socialLoginVector02 from '../../img/login/Vector 22_11.png'
 import kakaoLoginImg from '../../img/login/kakao_login_large 14_30.png'
 import googleLoginImg from '../../img/login/android_light_sq_na@4x 14_29.png'
-// import mainLogo from './main_logo_img_file.png'
+import {useNavigate} from "react-router-dom";
 
 const LoginPage = () => {
+    const navigate = useNavigate();
     const [loginRequest, setLoginRequest] = useState({
         username: "",
         password: "",
@@ -26,12 +26,9 @@ const LoginPage = () => {
         e.preventDefault();
         try {
             const response = await axios.post('/local/login', loginRequest);
-            console.log("로그인 성공 테스트 :");
-            console.log(response);
-            // TODO : 이전 페이지 및 홈화면으로 이동
+            navigate("/home");
         } catch (error) {
-            console.error("로그인 실패 테스트 : " + error);
-            // TODO : 사용자에게 실패 표시 보여주기
+            alert("아이디 및 비밀번호가 올바르지 않습니다.");
         }
     }
 
@@ -43,18 +40,18 @@ const LoginPage = () => {
 
                     <div className="absolute w-[369px] h-[544px] top-0 left-0 border-[0.5px] border-solid border-[#a5a2a2]">
                         <div
-                            className="absolute w-[249px] h-[46px] top-[50px] left-[60px] [font-family:'Pretendard-Variable'] font-normal text-black text-[40px] text-center tracking-[0] leading-[normal] ">NAELLU
+                            className="absolute w-[249px] h-[46px] top-[50px] left-[60px] font-sans font-normal text-black text-[40px] text-center tracking-[0] leading-[normal] ">NAELLU
                         </div>
 
                         <input
                             name="username"
-                            className="absolute w-[249px] h-[44px] top-[153px] left-[60px] bg-[#F5F5F5] border-[0.1px] border-solid border-[#C9C9C9] [font-family:'Pretendard-Variable'] font-normal text-[#8d8d8d] text-[12px] tracking-[0] leading-[normal] p-3"
+                            className="absolute w-[249px] h-[44px] top-[153px] left-[60px] bg-[#F5F5F5] border-[0.1px] border-solid border-[#C9C9C9] font-sans font-normal text-[#8d8d8d] text-[12px] tracking-[0] leading-[normal] p-3"
                             placeholder={"아이디 또는 이메일"}
                             onChange={handleChange}
                         />
                         <input
                             name="password"
-                            className="absolute w-[249px] h-[44px] top-[227px] left-[60px] bg-[#F5F5F5] border-[0.1px] border-solid border-[#C9C9C9] [font-family:'Pretendard-Variable'] font-normal text-[#8d8d8d] text-[12px] tracking-[0] leading-[normal] p-3"
+                            className="absolute w-[249px] h-[44px] top-[227px] left-[60px] bg-[#F5F5F5] border-[0.1px] border-solid border-[#C9C9C9] font-sans font-normal text-[#8d8d8d] text-[12px] tracking-[0] leading-[normal] p-3"
                             placeholder={"비밀번호"}
                             onChange={handleChange}
                         />
@@ -62,7 +59,7 @@ const LoginPage = () => {
                         <div
                             className="absolute w-[249px] h-[39px] top-[304px] left-[60px] bg-[#abeaff] rounded-[10px]">
                             <button
-                                className="top-[10px] left-[105px] [font-family:'Pretendard-Variable'] font-bold text-white text-[16px] whitespace-nowrap absolute tracking-[0] leading-[normal]"
+                                className="top-[10px] left-[105px] font-sans font-bold text-white text-[16px] whitespace-nowrap absolute tracking-[0] leading-[normal]"
                                 onClick={handleLogin}>
                                 로그인
                             </button>
@@ -91,7 +88,7 @@ const LoginPage = () => {
                         />
 
                         <div
-                            className="h-[16px] top-[498px] left-[119px] [font-family:'Pretendard-Variable'] font-light text-[#acacac] text-[13px] absolute tracking-[0] leading-[normal]">
+                            className="h-[16px] top-[498px] left-[119px] font-sans font-light text-[#acacac] text-[13px] absolute tracking-[0] leading-[normal]">
                             비밀번호를 잊으셨나요?
                         </div>
                     </div>
@@ -100,11 +97,11 @@ const LoginPage = () => {
                         className="absolute w-[369px] h-[80px] top-[564px] left-0 border-[0.5px] border-solid border-[#a4a2a2]">
                         <div className="relative w-[215px] h-[19px] top-[32px] left-[80px]">
                             <div
-                                className="h-[19px] -top-px left-0 [font-family:'Pretendard-Variable'] font-light text-black text-[16px] text-center whitespace-nowrap absolute tracking-[0] leading-[normal]">
+                                className="h-[19px] -top-px left-0 font-sans font-light text-black text-[16px] text-center whitespace-nowrap absolute tracking-[0] leading-[normal]">
                                 계정이 없으신가요?
                             </div>
                             <div
-                                className="h-[19px] -top-px left-[141px] [font-family:'Pretendard-Variable'] font-bold text-[#73aaea] text-[16px] text-center whitespace-nowrap absolute tracking-[0] leading-[normal]">
+                                className="h-[19px] -top-px left-[141px] font-sans font-bold text-[#73aaea] text-[16px] text-center whitespace-nowrap absolute tracking-[0] leading-[normal]">
                                 가입하기
                             </div>
                         </div>

--- a/front/src/img/home/icon_home.svg
+++ b/front/src/img/home/icon_home.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="29" viewBox="0 0 32 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 10.5556L16 2L30 10.5556" stroke="black" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M26.8889 16V25.9556C26.8889 26.4711 26.471 26.8889 25.9555 26.8889H6.04442C5.52895 26.8889 5.11108 26.4711 5.11108 25.9556V16" stroke="black" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -5,7 +5,11 @@ const withMT = require("@material-tailwind/react/utils/withMT");
 module.exports = withMT({
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Pretendard-Variable', 'sans-serif'],
+      }
+    },
   },
   plugins: [],
 });


### PR DESCRIPTION
- 홈페이지 UI를 나타내는 HomePage 컴포넌트 생성
- 로그인 성공 이후 '/home'으로 이동하는 useNavigate 사용
- App.js에 url마다 라우터 추가
- 폰트 사용법 간소화