### PR TITLE
[update] 로그인 - 성공 시 액세스 토큰도 발급되게 변경

### DIFF
--- a/front/src/component/home/HomePage.jsx
+++ b/front/src/component/home/HomePage.jsx
@@ -2,9 +2,11 @@ import React from "react";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {faBars, faMagnifyingGlass} from "@fortawesome/free-solid-svg-icons";
 import {faBell, faEnvelope, faSquarePlus, faUser} from "@fortawesome/free-regular-svg-icons";
+import axios from "axios";
 
 import homeIcon from "../../img/home/icon_home.svg";
 
+axios.defaults.withCredentials = 'true';
 
 const HomePage = () => {
 

--- a/src/main/java/myproject/sns/global/security/auth/AuthenticationService.java
+++ b/src/main/java/myproject/sns/global/security/auth/AuthenticationService.java
@@ -53,25 +53,25 @@ public class AuthenticationService {
 
     public AuthenticationResponse IssuingJwtTokens(String username) {
         User user = userRepository.findByName(username).orElseThrow();
-        String jwtToken = jwtService.generateToken(user);
+        String accessToken = jwtService.generateToken(user);
         String refreshToken = jwtService.generateRefreshToken(user);
 
         // 기존 토큰 강제 만료
         revokeAllUserTokens(user);
-        // 토큰 저장
-        saveUserToken(user, jwtToken);
+        // 리프레쉬 토큰 저장
+        saveUsersRefreshToken(user, refreshToken);
 
-        // 액세스 토큰, 리프레쉬 토큰 값을 가지는 AuthenticationResponse객체 반환
+        // 액세스 토큰, 리프레쉬 토큰 값을 가지는 AuthenticationResponse 반환
         return AuthenticationResponse.builder()
-                .accessToken(jwtToken)
+                .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
     }
 
-    private void saveUserToken(User user, String jwtToken) {
+    private void saveUsersRefreshToken(User user, String refreshToken) {
         Token token = Token.builder()
                 .user(user)
-                .token(jwtToken)
+                .token(refreshToken)
                 .tokenType(TokenType.BEARER)
                 .expired(false)
                 .revoked(false)
@@ -105,7 +105,7 @@ public class AuthenticationService {
             if (jwtService.isTokenValid(refreshToken, user)) {
                 String accessToken = jwtService.generateToken(user);
                 revokeAllUserTokens(user);
-                saveUserToken(user, accessToken);
+//                saveUserToken(user, accessToken);
                 AuthenticationResponse authResponse = AuthenticationResponse.builder()
                         .accessToken(accessToken)
                         .refreshToken(refreshToken)


### PR DESCRIPTION
- 로그인 커스텀 필터에 액세스 토큰을 응답 바디에 넣어 반환하는 코드를 추가
- 사용자에게 토큰 발급 시 DB에 저장되는 토큰을 액세스에서 리프레쉬로 변경