### PR TITLE
[update] 에러코드 403 -> 401, 404로 분리

### DIFF
--- a/src/main/java/myproject/sns/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/myproject/sns/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -35,4 +36,11 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResult, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(NoHandlerFoundException.class)
+    protected ResponseEntity<ErrorResult> handleNotFoundExceptions(NoHandlerFoundException ex) {
+        String errorMessage = "잘못된 요청 경로입니다.";
+        ErrorResult errorResult = new ErrorResult("NOT_FOUND", errorMessage);
+        log.error("[GlobalExceptionHandler] errorName: NoHandlerFoundException, message: {}", errorMessage);
+        return new ResponseEntity<>(errorResult, HttpStatus.NOT_FOUND);
+    }
 }

--- a/src/main/java/myproject/sns/global/exception/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/myproject/sns/global/exception/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,24 @@
+package myproject.sns.global.exception.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import myproject.sns.global.exception.ErrorResult;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        ErrorResult errorResult = new ErrorResult("UNAUTHORIZED", "인증되지 않은 요청입니다.");
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(new ObjectMapper().writeValueAsString(errorResult));
+    }
+}

--- a/src/main/java/myproject/sns/global/security/config/SecurityConfig.java
+++ b/src/main/java/myproject/sns/global/security/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package myproject.sns.global.security.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import myproject.sns.global.exception.handler.CustomAuthenticationEntryPoint;
 import myproject.sns.global.security.auth.AuthenticationService;
 import myproject.sns.global.security.filter.JwtAuthenticationFilter;
 import myproject.sns.global.security.filter.JwtLoginFilter;
@@ -37,12 +38,19 @@ public class SecurityConfig {
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationConfiguration authenticationConfiguration;
 
+    private static final String[] PERMIT_URL_ARRAY = {
+            "/login",
+            "/api/v1/user/register",
+            "/api/p1/**",
+            "/error"
+    };
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
                 .csrf().disable()
-                .authorizeRequests(req -> req.antMatchers("/", "/login", "/api/v1/user/register").permitAll()
+                .authorizeRequests(req -> req.antMatchers(PERMIT_URL_ARRAY).permitAll()
                         .anyRequest().authenticated())
 
                 .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
@@ -53,7 +61,9 @@ public class SecurityConfig {
                         logout.logoutUrl("/api/v1/auth/logout")
                                 .addLogoutHandler(logoutHandler)
                                 .logoutSuccessHandler((request, response, authentication) -> SecurityContextHolder.clearContext())
-                );
+                )
+                .exceptionHandling()
+                .authenticationEntryPoint(new CustomAuthenticationEntryPoint());
 
         return http.build();
     }

--- a/src/main/java/myproject/sns/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/myproject/sns/global/security/filter/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package myproject.sns.global.security.filter;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import myproject.sns.global.security.service.JwtService;
 import myproject.sns.global.security.dao.TokenRepository;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -18,6 +19,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -33,6 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull FilterChain filterChain) throws ServletException, IOException {
 
         if (request.getServletPath().contains("/api/v1")) {
+            log.error("/api/v1 경로로 시작했습니다");
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/myproject/sns/web/controller/post/PostController.java
+++ b/src/main/java/myproject/sns/web/controller/post/PostController.java
@@ -1,0 +1,23 @@
+package myproject.sns.web.controller.post;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/p1/post")
+public class PostController {
+
+    @GetMapping
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public ResponseEntity<?> postTest() {
+        return ResponseEntity.ok().body("test post controller");
+    }
+
+}


### PR DESCRIPTION
- 비로그인 상태에서 요청 시 api가 없거나 인증되지 않은 경우에도 403만 발생하던 상황을 분리
- 401 에러코드 처리를 위한 CustomAuthenticationEntryPoint 추가